### PR TITLE
Fix #62: Assembly instructions step 10 erroneously specify to mount a…

### DIFF
--- a/full_upgrade/for_mk3/manual/assembly_instructions/step10.md
+++ b/full_upgrade/for_mk3/manual/assembly_instructions/step10.md
@@ -24,7 +24,6 @@
 1. Find the correct tension for the belt. You can use the Prusa MK3 method from the original manual here : [Step 37 Testing the Y-axis belt](http://manual.prusa3d.com/Guide/2.+Y-axis+assembly/507?lang=en#s8300)
 1. Screw the motor back
 1. Take your time to perfectly align y_idler and y_motor_mount to get a good belt alignment
-1. Mount the Y end stop on the y_motor_mount
 
 
 ![](img/fig10.1.jpg)\


### PR DESCRIPTION
Fix for Issue #62 :

For the full Bear upgrade of the MK3, in the assembly manual step 10, the last item in the numbered list says "Mount the Y end stop on the y_motor_mount". This step does not apply to the MK3, and should be deleted.