### PR TITLE
Fix incorrect screw size for mounting of PSU to PSU lower mount

### DIFF
--- a/full_upgrade/for_mk3/manual/assembly_instructions/step15.md
+++ b/full_upgrade/for_mk3/manual/assembly_instructions/step15.md
@@ -10,9 +10,9 @@
 * 2x M4x12 screws (original ones used to assemble the PSU to the frame)
 * 2x M5x10 screws
 * 2x Tee nuts
-* 1x M3 washer (from the original PSU lower mount)
-* 1x M3 screw (from the original PSU lower mount)
-* 1x M3 nut (from the original PSU lower mount)
+* 1x M3 washer
+* 1x M3x18 screw (from the spares bag). Alternatively, if you have it, an M3x14 or M3x16 will work and is a more exact fit.
+* 1x M3 nut
 
 
 #### Assembly


### PR DESCRIPTION
Fix incorrect screw size for mounting of PSU to PSU lower mount (original M3x10 is too short).

Fix for issue #71 