### PR TITLE
Replace M5x10mm with M5x8mm

### DIFF
--- a/full_upgrade/for_mk3/manual/assembly_instructions/step01.md
+++ b/full_upgrade/for_mk3/manual/assembly_instructions/step01.md
@@ -9,14 +9,14 @@
 * 2x 331mm V-Slots
 * 1x 370mm V-Slots
 * 4x 90° joining plates
-* 12x M5x10mm screws
+* 12x M5x8mm screws
 * 24x Tee nuts
 
 #### Assembly
 
 1. If you did not get your 90° joining plates from RatRig, file sharp edges on the diagonal of 90° joining plates (figure 1.1). A small chamfer is enough, this just to avoid scratching cables and it will be useful for the next step as well
-1. Assemble 90° joining plates to the two 331mm v-slots as seen on figure 1.2 (with 8x M5x10 screws and 8x tee nuts). Do not tighten M5 screws yet
-1. Add 1x 370mm v-slot vertically as seen on figure 1.3 (with 4x M5x10 screws and 4x tee nuts). Do not tighten M5 screws yet
+1. Assemble 90° joining plates to the two 331mm v-slots as seen on figure 1.2 (with 8x M5x8mm screws and 8x tee nuts). Do not tighten M5 screws yet
+1. Add 1x 370mm v-slot vertically as seen on figure 1.3 (with 4x M5x8mm screws and 4x tee nuts). Do not tighten M5 screws yet
 1. Add 3 tee nuts on opposing sides of each of the 331mm v-slots (12x tee nuts in total) as seen on figure 1.4. The tee nuts go in the slots perpendicular to those to which the joining plates are attached. We will use these tee nuts later to attach the joining plates that hold the z-axis v-slots.
 
 

--- a/full_upgrade/for_mk3/manual/assembly_instructions/step02.md
+++ b/full_upgrade/for_mk3/manual/assembly_instructions/step02.md
@@ -8,14 +8,14 @@
 
 * 1x 370mm V-Slots
 * 1x 290mm V-Slots (used for distance reference)
-* 4x M5x10mm screws
+* 4x M5x8mm screws
 * 8x Tee nuts
 
 #### Assembly
 
 1. Ensure the 290mm v-slot does not have sharp angle where it as been cut. We will use it as reference and it could mark your v-slots (specially black ones). If this is the case use a file to smooth the sharp angles
 1. Place the 290mm v-slot on the back, between the 2x 331mm v-slots as seen on figure 2.1. Ensure there is no gap
-1. Square and tight strongly the back (8x M5 screws)<br>
+1. Square and strongly tighten the back (8x M5 screws)<br>
    :warning: this step is very important, double check everything is perfectly square
 1. Carefully remove the 290mm v-slot
 1. Add 4x tee nuts as explained on figure 2.1

--- a/full_upgrade/for_mk3/manual/assembly_instructions/step04.md
+++ b/full_upgrade/for_mk3/manual/assembly_instructions/step04.md
@@ -16,7 +16,7 @@
 1. Check the frame is not twisted by pressing down each corner (on the v-slots)
 1. If it is twisted, place an object (in red on figure 4.2) under one corner and apply pressure simultaneously to both perpendicular corners (A and B). Repeat this for left and right side until you get a perfectly flat frame<br>
    :warning: this step is very important, double check everything the frame is very flat and everything is still square
-1. Strongly tight frame screws and check others screws as well
+1. Strongly tighten frame screws and check others screws as well
 
 
 

--- a/full_upgrade/for_mk3/manual/assembly_instructions/step06.md
+++ b/full_upgrade/for_mk3/manual/assembly_instructions/step06.md
@@ -9,13 +9,13 @@
 * 1x 290mm v-slot
 * 2x 359mm v-slots
 * 6x 90° joining plates
-* 18x M5x10mm screws
+* 18x M5x8mm screws
 * 18x Tee nuts
 
 #### Assembly
 
 1. If you did not get your 90° joining plates from RatRig, file sharp edges on the diagonal of 2x 90° joining plates (figure 6.1). A small chamfer is enough, this just to avoid scratching cables
-1. Assemble 2x 359mm v-slots with one 290mm v-slot as seen on figure 6.2 with 2x 90° joining plates, 10x M5x10 screws and 10x tee nuts
+1. Assemble 2x 359mm v-slots with one 290mm v-slot as seen on figure 6.2 with 2x 90° joining plates, 10x M5x8 screws and 10x tee nuts
 1. Check all dimensions as seen on figure 6.3<br>
    :warning: this step is very important, double check everything is perfectly square
 1. File **all** sharp edges of 4x latest 90° joining plates (not only diagonals) (figure 6.1). A small chamfer is enough, this just to avoid scratching cables and it will be useful for the next step as well

--- a/full_upgrade/for_mk3/manual/assembly_instructions/step07.md
+++ b/full_upgrade/for_mk3/manual/assembly_instructions/step07.md
@@ -9,7 +9,7 @@
 * 1x build_helper_106mm
 * 1x Frame bottom
 * 1x Frame Z axis
-* 12x M5x10mm screws
+* 12x M5x8mm screws
 
 #### Assembly
 

--- a/full_upgrade/for_mk3/manual/bom.md
+++ b/full_upgrade/for_mk3/manual/bom.md
@@ -12,7 +12,7 @@
 | 90 degree joining plate | 10 | | [Openbuilds](http://openbuildspartstore.com/90-degree-joining-plate/) |
 | Tee-nuts M5 | 89 | 50x for 90° plates,<br> 8x for angle corner,<br> 31x for printed parts | [Openbuilds](http://openbuildspartstore.com/tee-nuts-10-pack/) |
 | M5x8mm low profile screw<br>(or button head ISO 7380) | 12 | 8x for angle corner,<br>4x RAMBo cover mounts | [Openbuilds](http://openbuildspartstore.com/low-profile-screws-m5-10-pack/)<br>[McMaster-Carr](https://www.mcmaster.com/#91239a222/=1clymbr)|
-| M5x8mm low profile screw<br>(or button head ISO 7380) | 46 | for 90° plates | [Openbuilds](http://openbuildspartstore.com/low-profile-screws-m5-10-pack/)<br>[McMaster-Carr](https://www.mcmaster.com/97763a819) |
+| M5x8mm low profile screw<br>(or button head ISO 7380) | 58 | for 90° plates | [Openbuilds](http://openbuildspartstore.com/low-profile-screws-m5-10-pack/)<br>[McMaster-Carr](https://www.mcmaster.com/97763a819) |
 | M5x10mm low profile screw<br>(or button head ISO 7380) | 17 | for printed parts | [Openbuilds](http://openbuildspartstore.com/low-profile-screws-m5-10-pack/)<br>[McMaster-Carr](https://www.mcmaster.com/#97763a820/=1cltxg0) |
 | M5x12mm low profile screw<br>(or button head ISO 7380) | 14 | 2x for y_motor_mount,<br>8x for rod_holders,<br>4x for feet | [Openbuilds](http://openbuildspartstore.com/low-profile-screws-m5-10-pack/)<br>[McMaster-Carr](https://www.mcmaster.com/#91239a228/=1cm065c) |
 | Self Tapping Screw M5 | 4 | 4x for top of Z axis<br>(Alternatively you can get 4x M5x8mm screws and a M5 tap) | [Openbuilds](http://openbuildspartstore.com/self-tapping-screw/) |

--- a/full_upgrade/for_mk3/manual/bom.md
+++ b/full_upgrade/for_mk3/manual/bom.md
@@ -12,7 +12,8 @@
 | 90 degree joining plate | 10 | | [Openbuilds](http://openbuildspartstore.com/90-degree-joining-plate/) |
 | Tee-nuts M5 | 89 | 50x for 90° plates,<br> 8x for angle corner,<br> 31x for printed parts | [Openbuilds](http://openbuildspartstore.com/tee-nuts-10-pack/) |
 | M5x8mm low profile screw<br>(or button head ISO 7380) | 12 | 8x for angle corner,<br>4x RAMBo cover mounts | [Openbuilds](http://openbuildspartstore.com/low-profile-screws-m5-10-pack/)<br>[McMaster-Carr](https://www.mcmaster.com/#91239a222/=1clymbr)|
-| M5x10mm low profile screw<br>(or button head ISO 7380) | 63 | 46x for 90° plates,<br> 17x for printed parts<br> | [Openbuilds](http://openbuildspartstore.com/low-profile-screws-m5-10-pack/)<br>[McMaster-Carr](https://www.mcmaster.com/#97763a820/=1cltxg0) |
+| M5x8mm low profile screw<br>(or button head ISO 7380) | 46 | for 90° plates | [Openbuilds](http://openbuildspartstore.com/low-profile-screws-m5-10-pack/)<br>[McMaster-Carr](https://www.mcmaster.com/97763a819) |
+| M5x10mm low profile screw<br>(or button head ISO 7380) | 17 | for printed parts | [Openbuilds](http://openbuildspartstore.com/low-profile-screws-m5-10-pack/)<br>[McMaster-Carr](https://www.mcmaster.com/#97763a820/=1cltxg0) |
 | M5x12mm low profile screw<br>(or button head ISO 7380) | 14 | 2x for y_motor_mount,<br>8x for rod_holders,<br>4x for feet | [Openbuilds](http://openbuildspartstore.com/low-profile-screws-m5-10-pack/)<br>[McMaster-Carr](https://www.mcmaster.com/#91239a228/=1cm065c) |
 | Self Tapping Screw M5 | 4 | 4x for top of Z axis<br>(Alternatively you can get 4x M5x8mm screws and a M5 tap) | [Openbuilds](http://openbuildspartstore.com/self-tapping-screw/) |
 | Set screw M5x4mm | 8 | for end_caps | [Openbuilds](http://openbuildspartstore.com/set-screw/) |


### PR DESCRIPTION
This pull request adjusts the instructions and BoM to use M5x8mm screws, instead of M5x10mm screws, when attaching the plates.